### PR TITLE
Add Auferet (memory-first AI game master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ An awesome list of low- and no-code generative AI resources.
 
 * [Copy.ai](copy.ai)
 * [Lex](https://lex.page/)
+* [Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
 * [Jasper](https://www.jasper.ai/)
 * [Notion AI](https://www.notion.so/product/ai)
 * [Rytr](https://rytr.me)


### PR DESCRIPTION
Adds Auferet, an AI game master for solo and multiplayer roleplaying games. It keeps your characters, world, and events in persistent memory and reads lore you upload, so the story stays consistent across long campaigns. Runs 5e and Pathfinder 2e, plays in the browser and on Android, free to start.

Website: https://auferet.com
